### PR TITLE
Fix memory corruption resulting from using call instead of farcall

### DIFF
--- a/battle/core.asm
+++ b/battle/core.asm
@@ -7911,7 +7911,7 @@ GiveBattleEVs:
 	; check held item
 	push bc
 	ld hl, BattleMonItem
-	call GetItemHeldEffect
+	farcall GetItemHeldEffect
 	ld a, b
 	cp HELD_EV_DOUBLE
 	call z, .item_double


### PR DESCRIPTION
Fixes GiveBattleEVs