### PR TITLE
Fix a bug where RestoreHP use the wrong target for animation purposes

### DIFF
--- a/battle/core.asm
+++ b/battle/core.asm
@@ -2109,19 +2109,14 @@ RestoreHP ; 3ccef
 	ld b, a
 	ld a, [hl]
 	sbc b
-	jr c, .asm_3cd2d
+	jr c, UpdateHPBarBattleHuds
 	ld a, b
 	ld [hli], a
 	ld [Buffer6], a
 	ld a, c
 	ld [hl], a
 	ld [Buffer5], a
-.asm_3cd2d
-
-	call SwitchTurnCore
-	call UpdateHPBarBattleHuds
-	jp SwitchTurnCore
-; 3cd36
+	; fallthrough
 
 UpdateHPBarBattleHuds: ; 3cd36
 	call UpdateHPBar

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -3983,9 +3983,7 @@ BattleCommand_Counter:
 BattleCommand_MirrorCoat:
 	ld b, EFFECT_MIRROR_COAT
 	ld c, SPECIAL
-BattleCommand_Counterattack: ; 35813
-; counter
-
+BattleCommand_Counterattack:
 	ld a, 1
 	ld [AttackMissed], a
 	ld a, BATTLE_VARS_LAST_COUNTER_MOVE_OPP
@@ -4045,8 +4043,6 @@ BattleCommand_Counterattack: ; 35813
 	xor a
 	ld [AttackMissed], a
 	ret
-
-; 35864
 
 
 BattleCommand_Encore: ; 35864


### PR DESCRIPTION
Forgot to switch a player<->enemy check when making RestoreHP restore
the user's HP...

Part of #59 