### PR TITLE
Fixes moves crashing

### DIFF
--- a/battle/core.asm
+++ b/battle/core.asm
@@ -480,7 +480,7 @@ GetSpeed::
 	farcall ApplySpeedAbilities
 	; Apply item effects
 	push bc
-	call GetUserItem
+	farcall GetUserItem
 	ld h, c
 	ld a, b
 	pop bc


### PR DESCRIPTION
Was introduced a while ago, only exposed now.
Was a farcall vs call bug

Fixes #63