### PR TITLE
Fix some issues with Trace

### DIFF
--- a/battle/core.asm
+++ b/battle/core.asm
@@ -4302,9 +4302,12 @@ RunBothActivationAbilities:
 	jr z, .got_order
 	call SetEnemyTurn
 .got_order
-	call RunActivationAbilities
+	; Don't run RunActivationAbilities, it
+	; will make Traced abilities activate
+	; twice
+	farcall RunActivationAbilitiesInner
 	call SwitchTurnCore
-	call RunActivationAbilities
+	farcall RunActivationAbilitiesInner
 	pop af
 	ld [hBattleTurn], a
 	ret

--- a/battle/effects/abilities.asm
+++ b/battle/effects/abilities.asm
@@ -150,6 +150,8 @@ TraceAbility:
 	cp IMPOSTER
 	jr z, .trace_failure
 	push af
+	ld b, a
+	farcall BufferAbility
 	ld a, BATTLE_VARS_ABILITY
 	call GetBattleVarAddr
 	pop af

--- a/text/battle.asm
+++ b/text/battle.asm
@@ -1280,7 +1280,9 @@ BecameHealthyText:
 TraceActivationText:
 	text "<USER>"
 	line "traced"
-	cont "<OPABIL>!"
+	cont "@"
+	text_from_ram StringBuffer1
+	text "!"
 	prompt
 
 TraceFailureText:


### PR DESCRIPTION
This makes 2 changes:
* The traced abilities are now correctly shown
* Traced abilities should no longer activate twice at a time where both Pokémon's activation abilities run

The reason the latter happens is because RunActivationAbilities has a wrapper around Trace to properly activate it when a new mon is switched out if it failed earlier, but this makes it run twice if called from RunBothActivationAbilities. So now it doesn't call the wrapper.

Fixes #77