### PR TITLE
Make things that afflict poison not afflict it against Steel types

### DIFF
--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -5014,6 +5014,8 @@ BattleCommand_Poison: ; 35f2c
 .no_ability
 	call CheckIfTargetIsPoisonType
 	jp z, .failed
+	call CheckIfTargetIsSteelType
+	jp z, .failed
 
 	ld a, BATTLE_VARS_STATUS_OPP
 	call GetBattleVar


### PR DESCRIPTION
This fixes a bug that is now dormant because Twineedle was removed. While it's dormant, it's probably a good idea to get up just in case to not forget later on.

Just getting this out there since it has been on my repository for almost a month. Going to look into getting started working on this again.