### PR TITLE
Add a NoRTC-FastTime build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ MD5 := md5sum -c --quiet
 
 VERSION = 2.2.0
 NAME = polishedcrystal-$(VERSION)
+NAME_NORTC = polishedcrystal-nortc-$(VERSION)
 FNAME = polishedcrystal-faithful-$(VERSION)
+FNAME_NORTC = polishedcrystal-faithful-nortc-$(VERSION)
 FAITHFUL =
+NORTC =
 
 TITLE = PKPCRYSTAL
 MCODE = PKPC
@@ -35,12 +38,17 @@ text/common_text.o \
 gfx/pics.o
 
 
-roms := $(NAME).gbc $(FNAME).gbc
+roms := $(NAME).gbc $(NAME_NORTC).gbc $(FNAME).gbc $(FNAME_NORTC).gbc
 
 all: crystal
 crystal: $(NAME).gbc
+nortc: NORTC += -DNO_RTC
+nortc: $(NAME_NORTC).gbc
 faithful: FAITHFUL += -DFAITHFUL
 faithful: $(FNAME).gbc
+faithful_nortc: FAITHFUL += -DFAITHFUL
+faithful_nortc: NORTC += -DNO_RTC
+faithful_nortc: $(FNAME_NORTC).gbc
 
 clean:
 	rm -f $(roms) $(crystal_obj) $(roms:.gbc=.map) $(roms:.gbc=.sym)
@@ -49,16 +57,24 @@ clean:
 
 %.o: dep = $(shell $(includes) $(@D)/$*.asm)
 %.o: %.asm $$(dep)
-	rgbasm $(FAITHFUL) -o $@ $<
+	rgbasm $(FAITHFUL) $(NORTC) -o $@ $<
 
 $(NAME).gbc: $(crystal_obj)
 	rgblink -n $(NAME).sym -m $(NAME).map -p $(FILLER) -o $@ $^
 	rgbfix -Cjv -t $(TITLE) -i $(MCODE) -n $(ROMVERSION) -p $(FILLER) -k 01 -l 0x33 -m 0x10 -r 3 $@
 
+$(NAME_NORTC).gbc: $(crystal_obj)
+	rgblink -n $(NAME_NORTC).sym -m $(NAME_NORTC).map -p $(FILLER) -o $@ $^
+	rgbfix -Cjv -t $(TITLE) -i $(MCODE) -n $(ROMVERSION) -p $(FILLER) -k 01 -l 0x33 -m 0x10 -r 3 $@
+	
 $(FNAME).gbc: $(crystal_obj)
 	rgblink -n $(FNAME).sym -m $(FNAME).map -p $(FILLER) -o $@ $^
 	rgbfix -Cjv -t $(TITLE) -i $(MCODE) -n $(ROMVERSION) -p $(FILLER) -k 01 -l 0x33 -m 0x10 -r 3 $@
 
+$(FNAME_NORTC).gbc: $(crystal_obj)
+	rgblink -n $(FNAME_NORTC).sym -m $(FNAME_NORTC).map -p $(FILLER) -o $@ $^
+	rgbfix -Cjv -t $(TITLE) -i $(MCODE) -n $(ROMVERSION) -p $(FILLER) -k 01 -l 0x33 -m 0x10 -r 3 $@
+	
 %.png: ;
 %.2bpp: %.png ; $(gfx) 2bpp $<
 %.1bpp: %.png ; $(gfx) 1bpp $<

--- a/engine/main_menu.asm
+++ b/engine/main_menu.asm
@@ -155,6 +155,21 @@ MainMenu_PrintCurrentTimeAndDay: ; 49e09
 	call CheckRTCStatus
 	and $80
 	jp nz, .PrintTimeNotSet
+	
+	;; kroc - NoRTC patch
+	;; to get the main menu to show the correct time of the save,
+	;; we need to pull the backed up RTC time from the save file
+	IF DEF(NO_RTC)
+		ld a, BANK(sPlayerData)
+		call GetSRAMBank
+		ld hl, sPlayerData + (wNoRTC - wPlayerData)
+		ld de, wNoRTC
+		ld bc, 5
+		call CopyBytes
+		call CloseSRAM
+	ENDC
+	;;
+	
 	call UpdateTime
 	call GetWeekday
 	ld b, a

--- a/home/game_time.asm
+++ b/home/game_time.asm
@@ -63,7 +63,20 @@ UpdateGameTimer:: ; 20ad
 .second
 	xor a
 	ld [hl], a
-
+	
+	;; kroc - noRTC Patch
+	;; the game timer has increased by 1-second:
+	;; increase the "fake" RTC by 6 seconds -- 24 in-game hours will pass in 4 real-world hours.
+	;; this does not affect the rate of the "hours played" time which remains real-time.
+	IF DEF(NO_RTC)
+		call UpdateNoRTC
+		call UpdateNoRTC
+		call UpdateNoRTC
+		call UpdateNoRTC
+		call UpdateNoRTC
+		call UpdateNoRTC
+	ENDC
+	
 ; +1 second
 	ld hl, GameTimeSeconds
 	ld a, [hl]
@@ -129,3 +142,53 @@ UpdateGameTimer:: ; 20ad
 	ld [GameTimeHours + 1], a
 	ret
 ; 210f
+
+;;----------------------------------------------------------------------------------------------------------------------
+
+;; kroc - noRTC Patch
+IF DEF(NO_RTC)
+UpdateNoRTC::
+	;; set our modulus
+	ld a, 60
+	ld b, a
+	
+	ld hl, wNoRTCSeconds
+	
+	; +1 second
+	ld a, b
+	inc [hl]
+	sub [hl]
+	ret nz
+	ld [hld], a
+	
+	; +1 minute
+	ld a, b
+	inc [hl]
+	sub [hl]
+	ret nz
+	ld [hld], a
+	
+	; +1 hour
+	;; 24-hours to a day
+	ld a, 24
+	inc [hl]
+	sub [hl]
+	ret nz
+	ld [hld], a
+	
+	;; the RTC stores days as a 16-bit number, it does not handle months
+	;; and so on as that's calculated by the game from the start date.
+	;; note that this is different than GameTime which just counts hours and not days
+	
+	; +1 day
+	;; increase the number of days (low)
+	inc [hl]
+	;; if that didn't overflow, leave
+	ret nc
+	;; TODO: only five bits are available on the hi-byte (the others are flags)
+	;; increase the days (hi)
+	inc hl
+	inc [hl]
+	
+	ret
+ENDC

--- a/wram.asm
+++ b/wram.asm
@@ -2280,6 +2280,17 @@ GameTimeFrames:: ; d4c8
 CurDay:: ; d4cb
 	ds 1
 
+;; Kroc - noRTC Patch
+;; backup of the fake RTC's contents:
+IF DEF(NO_RTC)
+wNoRTC::
+wNoRTCDayHi:: ds 1	;; = hRTCDayHi          EQU $ff8d
+wNoRTCDayLo:: ds 1	;; = hRTCDayLo          EQU $ff8e
+wNoRTCHours:: ds 1	;; = hRTCHours          EQU $ff8f
+wNoRTCMinutes:: ds 1	;; = hRTCMinutes        EQU $ff90
+wNoRTCSeconds:: ds 1	;; = hRTCSeconds        EQU $ff91
+ENDC
+	
 	ds 1
 wObjectFollow_Leader:: ds 1
 wObjectFollow_Follower:: ds 1


### PR DESCRIPTION
Creates "polishedcrystal-nortc.gbc" and
"polishedcrystal-faithful-nortc.gbc" ROMs:
- designed for hardware/emulators without Real Time Clock (RTC) support
- time runs at 6x speed; a full 24-hour cycle in-game takes 4 real hours