### PR TITLE
Refactor type matchups

### DIFF
--- a/battle/ai/items.asm
+++ b/battle/ai/items.asm
@@ -722,6 +722,8 @@ AI_HealStatus: ; 384e0
 	ld [EnemyMonStatus], a
 	ld hl, EnemySubStatus2
 	res SUBSTATUS_TOXIC, [hl]
+	ld hl, EnemySubStatus1
+	res SUBSTATUS_NIGHTMARE, [hl]
 	ret
 ; 384f7
 

--- a/battle/anim_commands.asm
+++ b/battle/anim_commands.asm
@@ -1364,10 +1364,10 @@ PlayHitSound: ; cc881
 
 .okay
 	ld a, [TypeModifier]
-	and $7f
+	and a
 	ret z
 
-	cp 10
+	cp $10
 	ld de, SFX_DAMAGE
 	jr z, .play
 

--- a/battle/core.asm
+++ b/battle/core.asm
@@ -1613,7 +1613,7 @@ HandleFutureSight: ; 3ca26
 	xor a
 	ld [AttackMissed], a
 	ld [AlreadyDisobeyed], a
-	ld a, 10
+	ld a, $10
 	ld [TypeModifier], a
 	farcall DoMove
 	xor a

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -1285,7 +1285,7 @@ BattleCommand_Stab: ; 346d2
 	ld a, BATTLE_VARS_ABILITY
 	call GetBattleVar
 	cp SCRAPPY
-	jp z, .TypesLoop
+	jp nz, .TypesLoop
 	jr .end
 
 .SkipForesightCheck:
@@ -1443,7 +1443,7 @@ _CheckTypeMatchup: ; 347d3
 	ld a, BATTLE_VARS_ABILITY
 	call GetBattleVar
 	cp SCRAPPY
-	jp z, .TypesLoop
+	jp nz, .TypesLoop
 	jr .End
 
 .Next:

--- a/battle/effect_commands.asm
+++ b/battle/effect_commands.asm
@@ -1249,6 +1249,7 @@ BattleCommand_Stab: ; 346d2
 	ld b, a
 	srl b
 	add b
+	ld [wTypeMatchup], a
 
 .stab_done
 	; Apply weather modifiers

--- a/battle/moves/move_effects.asm
+++ b/battle/moves/move_effects.asm
@@ -451,7 +451,6 @@ RockSmash:
 	supereffectivetext
 	checkdestinybond
 	buildopponentrage
-	effectchance
 	defensedown
 	statdownmessage
 	endmove

--- a/battle/type_matchup.asm
+++ b/battle/type_matchup.asm
@@ -1,9 +1,3 @@
-; The multiplier is divided by 10, so we can use values like 0.5.
-
-SUPER_EFFECTIVE    EQU 20
-NOT_VERY_EFFECTIVE EQU 05
-NO_EFFECT          EQU 00
-
 ; All other cases are neutral (1x).
 
 	;  attacker  defender*=

--- a/constants/battle_constants.asm
+++ b/constants/battle_constants.asm
@@ -7,6 +7,11 @@ REST_TURNS EQU 2
 MAX_STAT_LEVEL EQU 13
 BASE_STAT_LEVEL EQU 7
 
+; matchups, baseline is $10 for better doubling/halving
+SUPER_EFFECTIVE    EQU $20
+NOT_VERY_EFFECTIVE EQU $08
+NO_EFFECT          EQU 00
+
 	const_def
 	const ATTACK
 	const DEFENSE


### PR DESCRIPTION
GSC duplicates type matchup logic in the STAB function and has a serious case of overcomplication in it, so I rewrote it from scratch. This included handling of fire/water in sun/rain.

Also fixed Scrappy.

This should make tweaking of the actual type matchup function much easier to work with since there's less risk that you break everything else horribly by doing it.

As I did this, I discovered that pokecrystal has 2 variables named rather similar -- TypeModifier and wTypeMatchup. The latter is poorly named and, while used in type matchups (especially in the AI that only uses it and not TypeModifier at all), is also used in a lot of completely unrelated cases. Something that makes this worse is that pokecrystal has a hard time on whether to use wd265 or wTypeMatchup (it points to the same memory in the end, but this is a problem in case they ever happen to move around). I left this quirk in because I didn't feel like changing every occurence of it, and also had no idea what to rename it to anyway. The former is what the game actually uses when checking type matchup results in the battle engine itself.